### PR TITLE
Update pyo3

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -8,7 +8,7 @@ name = "amazing_calc"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["extension-module"] }
+pyo3 = { version = "0.17.0", features = ["extension-module"] }
 amazing_calc = { path = "../amazing_calc" }
 
 [dev-dependencies]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,14 +1,14 @@
+use amazing_calc as rust_amazing_calc;
 use pyo3::prelude::*;
-
 
 #[pyfunction]
 fn my_calc(a: i64, b: i64, c: i64) -> PyResult<String> {
-    Ok(amazing_calc::my_calc(a, b, c))
+    Ok(rust_amazing_calc::my_calc(a, b, c))
 }
 
-
 #[pymodule]
-fn amazing_calc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+#[pyo3(name = "amazing_calc")]
+fn python_amazing_calc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(my_calc, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
- Update Rust crate pyo3 to 0.17.0
- Rename functions due to name collision issues during macro expansion.
- Include & Close: https://github.com/kitsuyui/rust_binding_examples/pull/10.https://github.com/kitsuyui/rust_binding_examples/pull/10
